### PR TITLE
enable barcode option for single-end data

### DIFF
--- a/dupsifter.c
+++ b/dupsifter.c
@@ -912,6 +912,11 @@ void mark_dup(bam1_chain_t *bc, bam_hdr_t *hdr, ds_conf_t *conf, refcache_t *rs,
             return;
         }
 
+        // Extract packed barcode for single-end reads
+        if (conf->single_end && conf->has_barcode) {
+            packed_barcode = get_packed_barcode(r1, conf);
+        }
+        
         is_single = 1;
     } else {
         // Add MC and MQ tags if desired

--- a/dupsifter.c
+++ b/dupsifter.c
@@ -777,7 +777,7 @@ uint64_t get_packed_barcode(bam1_t *read1, ds_conf_t *conf) {
         uint8_t *full = s+1;
         s++;
         while (*s) {
-            if (*s != 'A' && *s != 'C' && *s != 'G' && *s != 'T' && *s != '+' && *s != '-') {
+            if (*s != 'N' && *s != 'A' && *s != 'C' && *s != 'G' && *s != 'T' && *s != '+' && *s != '-') {
                 fprintf(stderr, "[dupsifter] WARNING: Unable to parse barcode from CB tag ('barcode': %s). Using default barcode.\n", full);
 
                 return 0;
@@ -804,7 +804,7 @@ uint64_t get_packed_barcode(bam1_t *read1, ds_conf_t *conf) {
         uint8_t *full = s+1;
         s++;
         while (*s) {
-            if (*s != 'A' && *s != 'C' && *s != 'G' && *s != 'T' && *s != '+' && *s != '-') {
+            if (*s != 'N' && *s != 'A' && *s != 'C' && *s != 'G' && *s != 'T' && *s != '+' && *s != '-') {
                 fprintf(stderr, "[dupsifter] WARNING: Unable to parse barcode from CB tag ('barcode': %s). Using default barcode.\n", full);
 
                 return 0;
@@ -834,7 +834,7 @@ uint64_t get_packed_barcode(bam1_t *read1, ds_conf_t *conf) {
     if (last) {
         last++;
         while (*last) {
-            if (*last != 'A' && *last != 'C' && *last != 'G' && *last != 'T' && *last != '+' && *last != '-') {
+            if (*last != 'N' && *last != 'A' && *last != 'C' && *last != 'G' && *last != 'T' && *last != '+' && *last != '-') {
                 fprintf(stderr, "[dupsifter] WARNING: Unable to parse barcode from read name ('barcode': %s). Using default barcode.\n", full);
 
                 return 0;


### PR DESCRIPTION
minor fix, that allows for de-duplication of single-end data barcode wise. barcode option is now available for single-end data